### PR TITLE
Use crypt() instead of sha1

### DIFF
--- a/config.php
+++ b/config.php
@@ -22,7 +22,7 @@ $config['custom_setting'] = 'Hello'; 	// Can be accessed by {{ config.custom_set
 */
 
 $config['private'] = true;
-$config['private_pass']['admin'] = 'd033e22ae348aeb5660fc2140aec35850c4da997';
+$config['private_pass']['admin'] = '$1$Kjla/UpJ$fW6IpeViCyvMAP.jdq8IY/';
 
 
 

--- a/core/picturo.php
+++ b/core/picturo.php
@@ -60,10 +60,12 @@ class Picturo {
         $postUsername = $_POST['username'];
         $postPassword = $_POST['password'];
         if(isset($postUsername) && isset($postPassword)) {
-          if(isset($settings['private_pass'][$postUsername]) == true && $settings['private_pass'][$postUsername] == sha1($postPassword)) {
-            $_SESSION['authed'] = true;
-            $_SESSION['username'] = $postUsername;
-            $this->redirect('/');
+            if(isset($settings['private_pass'][$postUsername]) == true){
+               if(crypt($postPassword, $settings['private_pass'][$postUsername]) == crypt($postPassword)) {
+                    $_SESSION['authed'] = true;
+                    $_SESSION['username'] = $postUsername;
+                    $this->redirect('/');
+               }
           }
           $view_vars['login_error'] = 'Invalid login';
           $view_vars['username'] = $postUsername;


### PR DESCRIPTION
- The php documentations warns against the use of sha1 for passwords (http://www.php.net/manual/en/faq.passwords.php#faq.passwords.fasthash)
- The admin's password is now salted.
