### PR TITLE
Use crypt() instead of sha for password hashing

### DIFF
--- a/config.php
+++ b/config.php
@@ -22,7 +22,7 @@ $config['custom_setting'] = 'Hello'; 	// Can be accessed by {{ config.custom_set
 */
 
 $config['private'] = true;
-$config['private_pass']['admin'] = 'd033e22ae348aeb5660fc2140aec35850c4da997';
+$config['private_pass']['admin'] = '$1$GxdiQryg$BIbe/r0PYzU6jgBKlAZMh0';
 
 
 

--- a/core/picturo.php
+++ b/core/picturo.php
@@ -60,10 +60,13 @@ class Picturo {
         $postUsername = $_POST['username'];
         $postPassword = $_POST['password'];
         if(isset($postUsername) && isset($postPassword)) {
-          if(isset($settings['private_pass'][$postUsername]) == true && $settings['private_pass'][$postUsername] == sha1($postPassword)) {
-            $_SESSION['authed'] = true;
-            $_SESSION['username'] = $postUsername;
-            $this->redirect('/');
+            if(isset($settings['private_pass'][$postUsername]) == true){
+                $hashedPassword = $settings['private_pass'][$postUsername];
+               if(crypt($postPassword, $hashedPassword) == $hashedPassword) {
+                    $_SESSION['authed'] = true;
+                    $_SESSION['username'] = $postUsername;
+                    $this->redirect('/');
+               }
           }
           $view_vars['login_error'] = 'Invalid login';
           $view_vars['username'] = $postUsername;


### PR DESCRIPTION
The documentation (http://php.net/manual/en/faq.passwords.php) warns
against sha for passwords, and recommends crypt() instead.

The installation instructions should be updated accordingly.
